### PR TITLE
Melhoria nas exceções

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Gemfile.lock
+.ruby-version

--- a/cielo-ws15.gemspec
+++ b/cielo-ws15.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
                 "lib/cielo/ws15/token_message.rb",
                 "lib/cielo/ws15/transaction.rb",
                 "lib/cielo/ws15/transaction_message.rb",
+                "lib/cielo/ws15/exception.rb",
                 "lib/cielo/ws15.rb"]
 
   spec.add_dependency "bundler", "~> 1.6"

--- a/lib/cielo/ws15.rb
+++ b/lib/cielo/ws15.rb
@@ -174,7 +174,7 @@ module Cielo
       response = send_request(capture_message.serialize(transaction, total))
 
       return capture_message.unserialize(response, transaction)
-	  end
+    end
 
     # Envia uma requisicao-token para a Cielo
     #
@@ -187,7 +187,7 @@ module Cielo
       response = send_request(token_message.serialize(@merchant, holder))
 
       return token_message.unserialize(response)
-	  end
+    end
 
     # Envia uma requisicao-transacao para a Cielo
     #
@@ -200,7 +200,7 @@ module Cielo
       response = send_request(transaction_message.serialize(transaction))
 
       return transaction_message.unserialize(response, transaction)
-	  end
+    end
 
     private
     def send_request(message)

--- a/lib/cielo/ws15/exception.rb
+++ b/lib/cielo/ws15/exception.rb
@@ -1,0 +1,11 @@
+module Cielo
+  class IntegrationError < StandardError
+    attr_reader :code, :body
+
+    def initialize(args = {})
+      @code = args[:code]
+      @body = args[:body]
+      super("Cielo raises an integration error with code #{code}")
+    end
+  end
+end

--- a/lib/cielo/ws15/message.rb
+++ b/lib/cielo/ws15/message.rb
@@ -4,6 +4,7 @@ require "cielo/ws15/authorization"
 require "cielo/ws15/capture"
 require "cielo/ws15/cancellation"
 require "cielo/ws15/token"
+require "cielo/ws15/exception"
 
 # Helper para serialização e deserialização dos XML de requisição e resposta
 module Cielo::WS15Message
@@ -98,7 +99,7 @@ module Cielo::WS15Message
     code = document.xpath(".//erro/codigo").text
     message = document.xpath(".//erro/mensagem").text
 
-    raise "Erro[#{code}]: #{message}" unless code == ""
+    raise Cielo::IntegrationError.new(code: code, body: message) unless code.empty?
   end
 
   def self.load_document(message)


### PR DESCRIPTION
A forma como está implementado atualmente impossibilita o tratamento adequado dos erros levantados pela gem, pois será sempre o genérico `RuntimeError`.

Minha proposta é ter uma classe de erro específica, com o namespace da Cielo, com acesso ao código e a mensagem do erro.